### PR TITLE
#46 -Deals Api

### DIFF
--- a/src/MediaMath/TerminalOneAPI/Infrastructure/ApiHost.php
+++ b/src/MediaMath/TerminalOneAPI/Infrastructure/ApiHost.php
@@ -45,6 +45,9 @@ final class ApiHost
             case 'T1_ADAPTIVE_SEGMENTS':
                 $host = 'https://'.self::overrideDefaultValue('t1', $subdomain).'.mediamath.com/dmp/v'.self::overrideDefaultValue('2.0', $version).'/';
                 break;
+            case 'T1_MEDIA':
+                $host = 'https://'.self::overrideDefaultValue('t1', $subdomain).'.mediamath.com/media/v'.self::overrideDefaultValue('1.0', $version).'/';
+                break;
         }
 
         return $host;

--- a/src/MediaMath/TerminalOneAPI/Infrastructure/MediaApiObject.php
+++ b/src/MediaMath/TerminalOneAPI/Infrastructure/MediaApiObject.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mbucse
+ * Date: 14/06/2017
+ * Time: 16:27
+ */
+
+namespace MediaMath\TerminalOneAPI\Infrastructure;
+
+/**
+ * Class MediaApiObject
+ * @package MediaMath\TerminalOneAPI\Infrastructure
+ */
+abstract class MediaApiObject extends ApiObject
+{
+
+    /**
+     * @return mixed
+     */
+    abstract protected function endpoint();
+
+    /**
+     * @return string
+     */
+    public function uri()
+    {
+        return ApiHost::getHost('T1_MEDIA', $this->api_subdomain, $this->api_version) . $this->endpoint();
+    }
+
+}

--- a/src/MediaMath/TerminalOneAPI/Media/Deal.php
+++ b/src/MediaMath/TerminalOneAPI/Media/Deal.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace MediaMath\TerminalOneAPI\Media;
+
+use MediaMath\TerminalOneAPI\Infrastructure\Endpoint;
+use MediaMath\TerminalOneAPI\Infrastructure\MediaApiObject;
+use MediaMath\TerminalOneAPI\Infrastructure\NonDeletable;
+
+/**
+ * Class Deal
+ * @package MediaMath\TerminalOneAPI\Media
+ */
+class Deal extends MediaApiObject implements Endpoint
+{
+
+    use NonDeletable;
+
+    /**
+     * @return string
+     */
+    public function endpoint()
+    {
+        return 'deals';
+    }
+
+}

--- a/tests/MediaMath/TerminalOneApi/Management/DefaultResponseDecoderTest.php
+++ b/tests/MediaMath/TerminalOneApi/Management/DefaultResponseDecoderTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace Tests\MediaMath\TerminalOneApi\Management;
+
+use MediaMath\TerminalOneAPI\Decoder\DefaultResponseDecoder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Created by PhpStorm.
+ * User: mbucse
+ * Date: 02/12/2016
+ * Time: 15:42
+ */
+class DealTest  extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function decodeJson()
+    {
+        $headers = $this->getMockBuilder('MediaMath\TerminalOneAPI\Infrastructure\HttpResponseHeaders')->getMock();
+        $headers->method('contentType')->willReturn("application/json");
+        $api_response_mock = $this->getMockBuilder('MediaMath\TerminalOneAPI\Infrastructure\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $api_response_mock->method('headers')->willReturn($headers);
+        $api_response_mock->method('body')->willReturn(json_encode(['meta' => ['a' => 'b']]));
+        $obj = new DefaultResponseDecoder;
+        $obj->decode($api_response_mock);
+
+        $this->assertInstanceOf('MediaMath\TerminalOneAPI\Infrastructure\ApiResponseMeta', $obj->decode($api_response_mock)->meta());
+    }
+
+}


### PR DESCRIPTION
```php
use MediaMath\TerminalOneAPI\Auth\UserPasswordAuth;
use MediaMath\TerminalOneAPI\ApiClient;
use MediaMath\TerminalOneAPI\Transport\GuzzleTransporter;

$client = new ApiClient(new GuzzleTransporter(new UserPasswordAuth("user", password, "api_key")));

//get all deals
$deals = $client->read(new MediaMath\TerminalOneAPI\Media\Deal());
echo $deals->data();

//get first 5 deals
$deals = $client->read(new MediaMath\TerminalOneAPI\Media\Deal(["page_limit" => 5]));
echo $deals->data();

//get deal by id
$deals = $client->read(new MediaMath\TerminalOneAPI\Media\Deal(['id' => 123456]));
echo $deals->data();



```